### PR TITLE
gp3/gp4: extract note accent flags (0x02 heavy, 0x40 normal)

### DIFF
--- a/src/guitarpro/gp3.py
+++ b/src/guitarpro/gp3.py
@@ -899,7 +899,9 @@ class GP3File(GPFileBase):
         """
         flags = self.readU8()
         note.string = guitarString.number
+        note.effect.heavyAccentuatedNote = bool(flags & 0x02)
         note.effect.ghostNote = bool(flags & 0x04)
+        note.effect.accentuatedNote = bool(flags & 0x40)
         if flags & 0x20:
             note.type = gp.NoteType(self.readU8())
         if flags & 0x01:
@@ -1443,6 +1445,8 @@ class GP3File(GPFileBase):
         if note.velocity != gp.Velocities.default:
             flags |= 0x10
         flags |= 0x20
+        if note.effect.accentuatedNote:
+            flags |= 0x40
         return flags
 
     def writeNoteEffects(self, note):

--- a/src/guitarpro/gp4.py
+++ b/src/guitarpro/gp4.py
@@ -655,8 +655,6 @@ class GP4File(gp3.GP3File):
 
     def packNoteFlags(self, note):
         flags = super().packNoteFlags(note)
-        if note.effect.accentuatedNote:
-            flags |= 0x40
         if note.effect.isFingering:
             flags |= 0x80
         return flags

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -126,6 +126,37 @@ def testChord(tmpdir, caplog, filename):
     assert song == song2
 
 
+@pytest.mark.parametrize('filename', ['Effects.gp3', 'Effects.gp4', 'Effects.gp5'])
+def testNoteAccentuationRoundtrip(tmpdir, filename):
+    """Regression test for GP3/GP4 note accent flag extraction.
+
+    `GP3File.readNote` historically did not extract flag bits 0x02 (heavy
+    accent) and 0x40 (normal accent), while `writeNote` *does* write them.
+    GP4 inherits the broken read path; only GP5 read them correctly.
+
+    This caused a reader/writer asymmetry: accent flags were silently
+    dropped on every parse, even though PGP could write them.
+    """
+    filepath = LOCATION / filename
+    song = gp.parse(filepath)
+    note = song.tracks[0].measures[0].voices[0].beats[0].notes[0]
+
+    note.effect.accentuatedNote = True
+    note.effect.heavyAccentuatedNote = True
+
+    destpath = str(tmpdir.join(filename))
+    gp.write(song, destpath)
+    song2 = gp.parse(destpath)
+    note2 = song2.tracks[0].measures[0].voices[0].beats[0].notes[0]
+
+    assert note2.effect.accentuatedNote is True, (
+        f'{filename}: accentuatedNote not preserved on round-trip'
+    )
+    assert note2.effect.heavyAccentuatedNote is True, (
+        f'{filename}: heavyAccentuatedNote not preserved on round-trip'
+    )
+
+
 @pytest.mark.parametrize('version', ['gp3', 'gp4', 'gp5'])
 def testReadErrorAnnotation(version):
     def writeToBytesIO(song):


### PR DESCRIPTION
## Bug

`GP3File.readNote` never reads flag bits `0x02` (heavy accent) and `0x40` (normal accent) from the note flags byte, even though the docstring at `gp3.py:870-879` documents both flags. GP4 inherits this broken read path; only GP5 reads them correctly.

The writer side is asymmetric:
- `GP3File.packNoteFlags` emits `0x02` but not `0x40`
- `GP4File.packNoteFlags` overrides to add `0x40` only

Round-tripping a note with `accentuatedNote=True` through PGP silently drops the flag.

## Reference: alphaTab

alphaTab's `Gp3To5Importer.ts:1210-1217` shows the canonical read path for both flags:

```typescript
public readNote(track: Track, bar: Bar, voice: Voice, beat: Beat, stringIndex: number): Note {
    const flags = ...
    if ((flags & 0x02) !== 0) {
        newNote.accentuated = AccentuationType.Heavy;     // 0x02 = heavy accent
    } else if ((flags & 0x40) !== 0) {
        newNote.accentuated = AccentuationType.Normal;    // 0x40 = normal accent
    }
```

## Fix

- `GP3File.readNote`: read both flags 0x02 and 0x40 (mirroring AT)
- `GP3File.packNoteFlags`: write 0x40 alongside existing 0x02
- `GP4File.packNoteFlags`: drop the now-redundant 0x40 override (superseded by gp3)

## Verification

Added `testNoteAccentuationRoundtrip` in `tests/test_conversion.py`, parametrised over GP3/GP4/GP5 fixtures. Verifies both `accentuatedNote` and `heavyAccentuatedNote` survive a write→read cycle.

Without the fix:
- `Effects.gp3` fails (`accentuatedNote not preserved on round-trip`)
- `Effects.gp4` fails (same)
- `Effects.gp5` passes (already worked correctly)

With the fix: 3/3 tests pass.

All 195 existing tests continue to pass.
